### PR TITLE
Themes: Make dialpad seperator line theme-able (added OMS)

### DIFF
--- a/res/layout/dialpad_view_unthemed.xml
+++ b/res/layout/dialpad_view_unthemed.xml
@@ -56,7 +56,7 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="#e3e3e3" />
+            android:background="@color/dialpad_separator_color" />
 
     </LinearLayout>
 
@@ -148,7 +148,7 @@
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="#e3e3e3" />
+        android:background="@color/dialpad_separator_color" />
 
     <Space
         android:layout_width="match_parent"

--- a/res/values/projekt_colors.xml
+++ b/res/values/projekt_colors.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 Projekt Substratum
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<resources>
+    <color name="dialpad_separator_color">#e3e3e3</color>
+</resources>


### PR DESCRIPTION
Using an existing value in colors is defined
(dialpad_seperator_line_color) in AOSP, but overwritten in layout

Changed the original commit's color name due to layout was #e3e3e3 and
dialpad_seperator_line_color is #dadada

Change-Id: Ia4b610185bac6c34e0f6bd1b00a6f0c0480d5ee0